### PR TITLE
skip files that are disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ var wrapThis = amdWrap(fs.readFileSync(__filename));
 
 Line numbers will line up, although the first column will be shifted by
 `"define (function (require, exports, module) {".length` characters.
+
+## Exceptions
+
+It will not wrap if:
+- the file is already wrapped
+- the file starts with a comment `// amd-wrap:disable`

--- a/lib/amd-wrap.js
+++ b/lib/amd-wrap.js
@@ -1,7 +1,19 @@
 "use strict";
 
+var RE = {
+    alreadyWrapped: /^define\(function *\(require/,
+    oldStyle: /^\(function\(/,
+    disabled: /^\/[\/\*]+ *amd-wrap:disable/,
+};
+
+var leaveAlonePattern = new RegExp(
+    RE.alreadyWrapped.source + "|" +
+    RE.oldStyle.source + "|" +
+    RE.disabled.source
+);
+
 module.exports = function (commonJSModuleText) {
-    if (/^define\(function \(require/.test(commonJSModuleText)) {
+    if (leaveAlonePattern.test(commonJSModuleText)) {
         return commonJSModuleText;
     } else {
         return "define(function (require, exports, module) {" + commonJSModuleText + "\n});\n";

--- a/test/fixtures/disabledSlashStar.js
+++ b/test/fixtures/disabledSlashStar.js
@@ -1,0 +1,3 @@
+/* amd-wrap:disable
+ */
+window.someGlobal = 'pollution';

--- a/test/fixtures/disabledSlashes.js
+++ b/test/fixtures/disabledSlashes.js
@@ -1,0 +1,2 @@
+// amd-wrap:disable
+window.someGlobal = 'pollution';

--- a/test/fixtures/prewrappedSansSpace.js
+++ b/test/fixtures/prewrappedSansSpace.js
@@ -1,0 +1,3 @@
+define(function(require) {
+    return "foo";
+});

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ var amdWrap = require("..");
 
 // Why am I using Mocha for this, you ask? Because of the great string diffing, I answer.
 
-specify("It works", function () {
+specify("It wraps correctly", function () {
     var input = fs.readFileSync(path.resolve(__dirname, "fixtures/last.js"), "utf-8");
     var output = amdWrap(input);
     var expected = fs.readFileSync(path.resolve(__dirname, "fixtures/last.amd.js"), "utf-8");
@@ -18,7 +18,27 @@ specify("It works", function () {
 specify("It doesn't re-wrap when the string is already wrapped", function () {
     var input = fs.readFileSync(path.resolve(__dirname, "fixtures/last.amd.js"), "utf-8");
     var output = amdWrap(input);
-    var expected = fs.readFileSync(path.resolve(__dirname, "fixtures/last.amd.js"), "utf-8");
 
-    assert.strictEqual(output, expected);
+    assert.strictEqual(output, input);
+});
+
+specify("It doesn't re-wrap when the string is already wrapped without space", function () {
+    var input = fs.readFileSync(path.resolve(__dirname, "fixtures/prewrappedSansSpace.js"), "utf-8");
+    var output = amdWrap(input);
+
+    assert.strictEqual(output, input);
+});
+
+specify("It can be disabled in /* comment", function () {
+    var input = fs.readFileSync(path.resolve(__dirname, "fixtures/disabledSlashStar.js"), "utf-8");
+    var output = amdWrap(input);
+
+    assert.strictEqual(output, input);
+});
+
+specify("It can be disabled in // comment", function () {
+    var input = fs.readFileSync(path.resolve(__dirname, "fixtures/disabledSlashes.js"), "utf-8");
+    var output = amdWrap(input);
+
+    assert.strictEqual(output, input);
 });


### PR DESCRIPTION
This adds a new feature: skip files that start with a comment `amd-wrap:disable`.

It also simplifies the test logic a bit and adds more cases.
