### PR TITLE
add more checking for define function

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,14 @@ It takes in a string and gives back a string:
 ```js
 var amdWrap = require("amd-wrap");
 
+// wrap define around string
 var wrapped = amdWrap("module.exports = 5;");
+
+// wrap define around the string from file
 var wrapThis = amdWrap(fs.readFileSync(__filename));
+
+// wrap define and moduleName
+var wrapped = amdWrap("moduleName","module.exports = 5;");
 ```
 
 Line numbers will line up, although the first column will be shifted by

--- a/lib/amd-wrap.js
+++ b/lib/amd-wrap.js
@@ -1,9 +1,19 @@
 "use strict";
 
-module.exports = function (commonJSModuleText) {
-    if (/^define\(function \(require/.test(commonJSModuleText)) {
-        return commonJSModuleText;
+module.exports = function (moduleName, commonJSModuleText) {
+    var content;
+    var modulePartInDefine = "";
+    if(!commonJSModuleText) {
+        content = moduleName;
     } else {
-        return "define(function (require, exports, module) {" + commonJSModuleText + "\n});\n";
+        modulePartInDefine = moduleName ? ("'" + moduleName + "', ") : "";
+        content = commonJSModuleText;
+    }
+    if (/^\s*?define\(\s*?.*?function\s*?\(\s*?require/.test(content)) {
+        return content;
+    } else {
+        return "define(" + modulePartInDefine +  "function (require, exports, module) {\n" +
+            content +
+            "\n});\n";
     }
 };

--- a/test/fixtures/blank.before.amd.js
+++ b/test/fixtures/blank.before.amd.js
@@ -1,3 +1,4 @@
+
 define(function (require, exports, module) {
 "use strict";
 

--- a/test/fixtures/more.param.amd.js
+++ b/test/fixtures/more.param.amd.js
@@ -1,4 +1,4 @@
-define(function (require, exports, module) {
+define('moduleName', function (require, exports, module) {
 "use strict";
 
 var pending = { then: function () {} };

--- a/test/test.js
+++ b/test/test.js
@@ -15,10 +15,34 @@ specify("It works", function () {
     assert.strictEqual(output, expected);
 });
 
+specify("It works when pass a module name", function () {
+    var input = fs.readFileSync(path.resolve(__dirname, "fixtures/last.js"), "utf-8");
+    var output = amdWrap('moduleName', input);
+    var expected = fs.readFileSync(path.resolve(__dirname, "fixtures/more.param.amd.js"), "utf-8");
+
+    assert.strictEqual(output, expected);
+});
+
 specify("It doesn't re-wrap when the string is already wrapped", function () {
     var input = fs.readFileSync(path.resolve(__dirname, "fixtures/last.amd.js"), "utf-8");
     var output = amdWrap(input);
     var expected = fs.readFileSync(path.resolve(__dirname, "fixtures/last.amd.js"), "utf-8");
+
+    assert.strictEqual(output, expected);
+});
+
+specify("It doesn't re-wrap when the string is already wrapped and there is one blank before define", function () {
+    var input = fs.readFileSync(path.resolve(__dirname, "fixtures/blank.before.amd.js"), "utf-8");
+    var output = amdWrap(input);
+    var expected = fs.readFileSync(path.resolve(__dirname, "fixtures/blank.before.amd.js"), "utf-8");
+
+    assert.strictEqual(output, expected);
+});
+
+specify("It doesn't re-wrap when the string is already wrapped and there is more param in define", function () {
+    var input = fs.readFileSync(path.resolve(__dirname, "fixtures/more.param.amd.js"), "utf-8");
+    var output = amdWrap(input);
+    var expected = fs.readFileSync(path.resolve(__dirname, "fixtures/more.param.amd.js"), "utf-8");
 
     assert.strictEqual(output, expected);
 });


### PR DESCRIPTION
and support modulename to be inserted in define.

```
var wrapped = amdWrap("moduleName","module.exports = 5;");
```
